### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: :new
   def index
-    @items = Item.all.order('created_at DESC')
+    @items = Item.includes(:user).order('created_at DESC')
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: :new
   def index
-    # @items = Item.all.order('created_at DESC')
+    @items = Item.all.order('created_at DESC')
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -9,7 +9,7 @@ class Item < ApplicationRecord
   with_options presence: true do
     validates :name
     validates :description
-    validates :price,      inclusion: { in: 300..9_999_999_999 }
+    validates :price, inclusion: { in: 300..9_999_999_999 }
     validates :image
   end
 

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -1,7 +1,7 @@
  <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%#= image_tag item.image, class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
         
@@ -14,10 +14,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%#= item.name %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%#= item.price %>円<br><%#= item.cost_beaver.name %></span>
+            <span><%= item.price %>円<br><%= item.cost_beaver.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,7 +126,7 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%#= render partial: "item", collection: @items %>
+      <%= render partial: "item", collection: @items %>
 
       <% unless @items.present? %>
       <li class='list'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,9 +126,9 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
+      <% if @items.present? %>
       <%= render partial: "item", collection: @items %>
-
-      <% unless @items.present? %>
+      <% else %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Item, type: :model do
         expect(@item.errors.full_messages).to include('Price is not included in the list')
       end
       it '価格が10000000000以上であると出品できない' do
-        @item.price = 10000000000
+        @item.price = 10_000_000_000
         @item.valid?
         expect(@item.errors.full_messages).to include('Price is not included in the list')
       end


### PR DESCRIPTION
# what
トップページへ商品を表示
# why
商品一覧表示機能の実装のため

商品購入機能実装前のため「売却済みの商品は、画像上に『sold out』の文字が表示されるようになっていること」という機能に関しては未実装